### PR TITLE
Add GitHub Action to automatically sync main and develop branches

### DIFF
--- a/.github/workflows/branch_sync.yml
+++ b/.github/workflows/branch_sync.yml
@@ -1,0 +1,30 @@
+name: Branch Sync
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  sync_branches:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "{{ secrets.PERSONAL_EMAIL }}"
+
+      - name: Merge main into develop
+        run: |
+          git checkout develop
+          git merge --no-edit main
+          git push origin develop


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow that automatically syncs the `develop` branch with the `main` branch after a pull request is merged into `main`. This will help keep the branches in sync without having to do it manually.

The workflow is triggered every time a pull request is merged into the `main` branch. It checks out the `develop` branch, merges `main` into it, and pushes the changes to the remote `develop` branch.

Please note that if there are conflicts during the merge, the workflow will fail, and we will have to resolve them manually.

Changes in this PR:
- Created a new GitHub Actions workflow file at `.github/workflows/branch_sync.yml`