### PR TITLE
Removed phpcs which I created in error and renamed the core workflow …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: Main
 
 on:
   push:


### PR DESCRIPTION
### Feature Description

Deleted empty `phpsc.yml`, moved phpcs configuration to `php.yml`, and renamed `php.yml` to `main.yml`.

### Motivation

The motivation behind this change is to clean up the repository by removing an unnecessary file and consolidating the GitHub workflow configuration into a single, more standard file name.

### Implementation

- Deleted the empty `phpsc.yml` file.
- Moved the phpcs configuration from `phpsc.yml` to `php.yml`.
- Renamed `php.yml` to `main.yml`.

### Testing

No new tests are necessary as these changes involve GitHub workflow configuration files. However, the updated GitHub workflow should be tested by triggering a new build to ensure it runs successfully with the new file name and configuration.

### Documentation

No documentation updates are necessary as these changes are related to internal GitHub workflow configuration.

### Screenshots or Demos

N/A

### Additional Context

Consolidating the GitHub workflow configuration into a single file with a more standard name will help maintain a clean and organized repository structure.
